### PR TITLE
Add support for splashscreens added using LaunchStoryboard

### DIFF
--- a/src/ios/PrivacyScreenPlugin.m
+++ b/src/ios/PrivacyScreenPlugin.m
@@ -38,6 +38,11 @@ UIImageView *imageView;
   } else {
     imageView = [[UIImageView alloc]initWithFrame:[self.viewController.view bounds]];
     [imageView setImage:splash];
+
+    if ([self isUsingCDVLaunchScreen]) {
+        // launch screen expects the image to be scaled using AspectFill.
+        imageView.contentMode = UIViewContentModeScaleAspectFill;
+    }
     
     #ifdef __CORDOVA_4_0_0
         [[UIApplication sharedApplication].keyWindow addSubview:imageView];
@@ -76,10 +81,25 @@ UIImageView *imageView;
   return device;
 }
 
+- (BOOL) isUsingCDVLaunchScreen {
+    NSString* launchStoryboardName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UILaunchStoryboardName"];
+    if (launchStoryboardName) {
+        return ([launchStoryboardName isEqualToString:@"CDVLaunchScreen"]);
+    } else {
+        return NO;
+    }
+}
+
 - (NSString*)getImageName:(UIInterfaceOrientation)currentOrientation delegate:(id<CDVScreenOrientationDelegate>)orientationDelegate device:(CDV_iOSDevice)device
 {
   // Use UILaunchImageFile if specified in plist.  Otherwise, use Default.
   NSString* imageName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UILaunchImageFile"];
+
+   // detect if we are using Launch Storyboard; if so, return the associated image instead
+  if ([self isUsingCDVLaunchScreen]) {
+    imageName = @"LaunchStoryboard";
+    return imageName;
+  }
 
   NSUInteger supportedOrientations = [orientationDelegate supportedInterfaceOrientations];
 


### PR DESCRIPTION
Hi,

This PR adds support for splashscreens added using Launch storyboard images. Without this it just shows an black screen on iOS in the app switcher.

Uses the same way to the get image as the Cordova Splash screen plugin: (https://github.com/apache/cordova-plugin-splashscreen/blob/rel/5.0.3/src/ios/CDVSplashScreen.m#L196-L200)

`UIViewContentModeScaleAspectFill` ensures the aspect ratio is correct (https://github.com/apache/cordova-plugin-splashscreen/blob/rel/5.0.3/src/ios/CDVSplashScreen.m#L360-L366)
